### PR TITLE
Include nested evaluator details in judge list response

### DIFF
--- a/src/root_signals_mcp/root_api_client.py
+++ b/src/root_signals_mcp/root_api_client.py
@@ -435,11 +435,16 @@ class RootSignalsJudgeRepository(RootSignalsRepositoryBase):
 
                 description = judge_data.get("intent")
 
+                evaluators: list[JudgeInfo.NestedEvaluatorInfo] = []
+                for evaluator_data in judge_data.get("evaluators", []):
+                    evaluators.append(JudgeInfo.NestedEvaluatorInfo.model_validate(evaluator_data))
+
                 judge = JudgeInfo(
                     id=id_value,
                     name=name_value,
                     created_at=created_at,
                     description=description,
+                    evaluators=evaluators,
                 )
                 judges.append(judge)
             except KeyError as e:

--- a/src/root_signals_mcp/schema.py
+++ b/src/root_signals_mcp/schema.py
@@ -211,9 +211,17 @@ class JudgeInfo(BaseRootSignalsModel):
     Model for judge information.
     """
 
+    class NestedEvaluatorInfo(BaseRootSignalsModel):
+        """Nested evaluator info."""
+
+        name: str = Field(..., description="Name of the evaluator")
+        id: str = Field(..., description="ID of the evaluator")
+        intent: str | None = Field(default="", description="Intent of the evaluator")
+
     name: str = Field(..., description="Name of the judge")
     id: str = Field(..., description="ID of the judge")
     created_at: str = Field(..., description="Creation timestamp of the judge")
+    evaluators: list[NestedEvaluatorInfo] = Field(..., description="List of evaluators")
     description: str | None = Field(None, description="Description of the judge")
 
 

--- a/src/root_signals_mcp/test/test_client.py
+++ b/src/root_signals_mcp/test/test_client.py
@@ -124,6 +124,14 @@ async def test_client_list_judges(compose_up_mcp_server: Any) -> None:
         assert "id" in first_judge
         assert "name" in first_judge
 
+        assert "evaluators" in first_judge
+        assert isinstance(first_judge["evaluators"], list)
+        assert len(first_judge["evaluators"]) > 0
+
+        for evaluator in first_judge["evaluators"]:
+            assert "id" in evaluator
+            assert "name" in evaluator
+
         logger.info(f"Found {len(judges)} judges")
         logger.info(f"First judge: {first_judge['name']}")
     finally:


### PR DESCRIPTION
Includes basic details to give more context to the model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Judge information now includes detailed evaluator data, providing names, IDs, and optional intent for each evaluator.
- **Tests**
  - Enhanced tests to verify the presence and structure of evaluator information within judge data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->