### PR TITLE
Merge RAG and normal evaluation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ This project serves as a bridge between Root Signals API and MCP client applicat
 ## Features
 
 - Exposes Root Signals evaluators as MCP tools
-- Supports both standard evaluation and RAG evaluation with contexts
 - Implements SSE for network deployment
 - Compatible with various MCP clients such as [Cursor](https://docs.cursor.com/context/model-context-protocol)
 
@@ -46,8 +45,6 @@ The server exposes the following tools:
 1. `list_evaluators` - Lists all available evaluators on your Root Signals account
 2. `run_evaluation` - Runs a standard evaluation using a specified evaluator ID
 3. `run_evaluation_by_name` - Runs a standard evaluation using a specified evaluator name
-4. `run_rag_evaluation` - Runs a RAG evaluation with contexts using a specified evaluator ID
-5. `run_rag_evaluation_by_name` - Runs a RAG evaluation with contexts using a specified evaluator name
 6. `run_coding_policy_adherence` - Runs a coding policy adherence evaluation using policy documents such as AI rules files
 7. `list_judges` - Lists all available judges on your Root Signals account. A judge is a collection of evaluators forming LLM-as-a-judge.
 8. `run_judge` - Runs a judge using a specified judge ID
@@ -168,7 +165,7 @@ async def main():
         )
         print(f"Evaluation by name score: {result['score']}")
         
-        result = await mcp_client.run_rag_evaluation(
+        result = await mcp_client.run_evaluation(
             evaluator_id="eval-987654321",
             request="What is the capital of France?",
             response="The capital of France is Paris.",
@@ -176,7 +173,7 @@ async def main():
         )
         print(f"RAG evaluation score: {result['score']}")
         
-        result = await mcp_client.run_rag_evaluation_by_name(
+        result = await mcp_client.run_evaluation_by_name(
             evaluator_name="Faithfulness",
             request="What is the capital of France?",
             response="The capital of France is Paris.",

--- a/demonstrations/example_pydantic-ai.py
+++ b/demonstrations/example_pydantic-ai.py
@@ -28,7 +28,7 @@ agent_prompt = """
     </instructions>
 
     <acceptance_criteria>
-    - Response candidate must score above 0.7 as indicated by Root Signals evaluators
+    - Response candidate must score above 0.7 as indicated by Root Signals evaluators. Use the contents of the policy and current_state tags as the context parameter.
     - At least 2 evaluators from the list of evaluators have been used on your response candidate
     - If evaluators are not available or give errors, respond to the customer with a temporary apology
     </acceptance_criteria>

--- a/src/root_signals_mcp/client.py
+++ b/src/root_signals_mcp/client.py
@@ -120,7 +120,12 @@ class RootSignalsMCPClient:
         return result.get("evaluators", [])  # type: ignore
 
     async def run_evaluation(
-        self, evaluator_id: str, request: str, response: str, contexts: list[str] | None = None
+        self,
+        evaluator_id: str,
+        request: str,
+        response: str,
+        contexts: list[str] | None = None,
+        expected_output: str | None = None,
     ) -> dict[str, Any]:
         """Run a standard evaluation using a RootSignals evaluator by ID.
 
@@ -129,6 +134,7 @@ class RootSignalsMCPClient:
             request: The user request/query
             response: The model's response to evaluate
             contexts: Optional list of contexts (policy files, examples, etc.) used for generation. Only used for evaluators that require contexts.
+            expected_output: Optional expected LLM response. Only used for evaluators that require expected output.
 
         Returns:
             Evaluation result with score and justification
@@ -138,12 +144,18 @@ class RootSignalsMCPClient:
             "request": request,
             "response": response,
             "contexts": contexts,
+            "expected_output": expected_output,
         }
 
         return await self.call_tool("run_evaluation", arguments)
 
     async def run_evaluation_by_name(
-        self, evaluator_name: str, request: str, response: str, contexts: list[str] | None = None
+        self,
+        evaluator_name: str,
+        request: str,
+        response: str,
+        contexts: list[str] | None = None,
+        expected_output: str | None = None,
     ) -> dict[str, Any]:
         """Run a standard evaluation using a RootSignals evaluator by name.
 
@@ -152,6 +164,7 @@ class RootSignalsMCPClient:
             request: The user request/query
             response: The model's response to evaluate
             contexts: Optional list of contexts (policy files, examples, etc.) used for generation. Only used for evaluators that require contexts.
+            expected_output: Optional expected LLM response. Only used for evaluators that require expected output.
 
         Returns:
             Evaluation result with score and justification
@@ -161,6 +174,7 @@ class RootSignalsMCPClient:
             "request": request,
             "response": response,
             "contexts": contexts,
+            "expected_output": expected_output,
         }
 
         return await self.call_tool("run_evaluation_by_name", arguments)

--- a/src/root_signals_mcp/client.py
+++ b/src/root_signals_mcp/client.py
@@ -120,7 +120,7 @@ class RootSignalsMCPClient:
         return result.get("evaluators", [])  # type: ignore
 
     async def run_evaluation(
-        self, evaluator_id: str, request: str, response: str
+        self, evaluator_id: str, request: str, response: str, contexts: list[str] | None = None
     ) -> dict[str, Any]:
         """Run a standard evaluation using a RootSignals evaluator by ID.
 
@@ -128,49 +128,7 @@ class RootSignalsMCPClient:
             evaluator_id: ID of the evaluator to use
             request: The user request/query
             response: The model's response to evaluate
-
-        Returns:
-            Evaluation result with score and justification
-        """
-        arguments = {
-            "evaluator_id": evaluator_id,
-            "request": request,
-            "response": response,
-        }
-
-        return await self.call_tool("run_evaluation", arguments)
-
-    async def run_evaluation_by_name(
-        self, evaluator_name: str, request: str, response: str
-    ) -> dict[str, Any]:
-        """Run a standard evaluation using a RootSignals evaluator by name.
-
-        Args:
-            evaluator_name: Name of the evaluator to use
-            request: The user request/query
-            response: The model's response to evaluate
-
-        Returns:
-            Evaluation result with score and justification
-        """
-        arguments = {
-            "evaluator_name": evaluator_name,
-            "request": request,
-            "response": response,
-        }
-
-        return await self.call_tool("run_evaluation_by_name", arguments)
-
-    async def run_rag_evaluation(
-        self, evaluator_id: str, request: str, response: str, contexts: list[str]
-    ) -> dict[str, Any]:
-        """Run a RAG evaluation with contexts using a RootSignals evaluator by ID.
-
-        Args:
-            evaluator_id: ID of the evaluator to use
-            request: The user request/query
-            response: The model's response to evaluate
-            contexts: List of context passages used for generation
+            contexts: Optional list of contexts (policy files, examples, etc.) used for generation. Only used for evaluators that require contexts.
 
         Returns:
             Evaluation result with score and justification
@@ -182,7 +140,30 @@ class RootSignalsMCPClient:
             "contexts": contexts,
         }
 
-        return await self.call_tool("run_rag_evaluation", arguments)
+        return await self.call_tool("run_evaluation", arguments)
+
+    async def run_evaluation_by_name(
+        self, evaluator_name: str, request: str, response: str, contexts: list[str] | None = None
+    ) -> dict[str, Any]:
+        """Run a standard evaluation using a RootSignals evaluator by name.
+
+        Args:
+            evaluator_name: Name of the evaluator to use
+            request: The user request/query
+            response: The model's response to evaluate
+            contexts: Optional list of contexts (policy files, examples, etc.) used for generation. Only used for evaluators that require contexts.
+
+        Returns:
+            Evaluation result with score and justification
+        """
+        arguments = {
+            "evaluator_name": evaluator_name,
+            "request": request,
+            "response": response,
+            "contexts": contexts,
+        }
+
+        return await self.call_tool("run_evaluation_by_name", arguments)
 
     async def run_rag_evaluation_by_name(
         self, evaluator_name: str, request: str, response: str, contexts: list[str]
@@ -205,7 +186,7 @@ class RootSignalsMCPClient:
             "contexts": contexts,
         }
 
-        return await self.call_tool("run_rag_evaluation_by_name", arguments)
+        return await self.call_tool("run_evaluation_by_name", arguments)
 
     async def run_coding_policy_adherence(
         self, policy_documents: list[str], code: str

--- a/src/root_signals_mcp/core.py
+++ b/src/root_signals_mcp/core.py
@@ -27,8 +27,6 @@ from root_signals_mcp.schema import (
     JudgesListResponse,
     ListEvaluatorsRequest,
     ListJudgesRequest,
-    RAGEvaluationByNameRequest,
-    RAGEvaluationRequest,
     RunJudgeRequest,
     RunJudgeResponse,
     UnknownToolRequest,
@@ -58,9 +56,7 @@ class RootMCPServerCore:  # noqa: D101
         self._function_map: dict[str, _Handler] = {
             "list_evaluators": self._handle_list_evaluators,
             "run_evaluation": self._handle_run_evaluation,
-            "run_rag_evaluation": self._handle_run_rag_evaluation,
             "run_evaluation_by_name": self._handle_run_evaluation_by_name,
-            "run_rag_evaluation_by_name": self._handle_run_rag_evaluation_by_name,
             "run_coding_policy_adherence": self._handle_coding_style_evaluation,
             "list_judges": self._handle_list_judges,
             "run_judge": self._handle_run_judge,
@@ -137,29 +133,19 @@ class RootMCPServerCore:  # noqa: D101
         logger.debug("Handling run_evaluation_by_name for evaluator %s", params.evaluator_name)
         return await self.evaluator_service.run_evaluation_by_name(params)
 
-    async def _handle_run_rag_evaluation(self, params: RAGEvaluationRequest) -> EvaluationResponse:
-        logger.debug("Handling run_rag_evaluation for evaluator %s", params.evaluator_id)
-        return await self.evaluator_service.run_rag_evaluation(params)
-
-    async def _handle_run_rag_evaluation_by_name(
-        self, params: RAGEvaluationByNameRequest
-    ) -> EvaluationResponse:
-        logger.debug("Handling run_rag_evaluation_by_name for evaluator %s", params.evaluator_name)
-        return await self.evaluator_service.run_rag_evaluation_by_name(params)
-
     async def _handle_coding_style_evaluation(
         self, params: CodingPolicyAdherenceEvaluationRequest
     ) -> EvaluationResponse:
         logger.debug("Handling run_coding_policy_adherence request")
 
-        rag_request = RAGEvaluationRequest(
+        rag_request = EvaluationRequest(
             evaluator_id=settings.coding_policy_evaluator_id,
             request=settings.coding_policy_evaluator_request,
             response=params.code,
             contexts=params.policy_documents,
         )
 
-        return await self.evaluator_service.run_rag_evaluation(rag_request)
+        return await self.evaluator_service.run_evaluation(rag_request)
 
     async def _handle_list_judges(self, _params: ListJudgesRequest) -> JudgesListResponse:
         """Handle list_judges tool call."""

--- a/src/root_signals_mcp/evaluator.py
+++ b/src/root_signals_mcp/evaluator.py
@@ -16,8 +16,6 @@ from root_signals_mcp.schema import (
     EvaluationResponse,
     EvaluatorInfo,
     EvaluatorsListResponse,
-    RAGEvaluationByNameRequest,
-    RAGEvaluationRequest,
 )
 from root_signals_mcp.settings import settings
 
@@ -117,6 +115,7 @@ class EvaluatorService:
                 evaluator_id=request.evaluator_id,
                 request=request.request,
                 response=request.response,
+                contexts=request.contexts,
             )
 
             return result
@@ -147,6 +146,7 @@ class EvaluatorService:
                 evaluator_name=request.evaluator_name,
                 request=request.request,
                 response=request.response,
+                contexts=request.contexts,
             )
 
             return result
@@ -161,70 +161,3 @@ class EvaluatorService:
         except Exception as e:
             logger.error(f"Error running evaluation by name: {e}", exc_info=settings.debug)
             raise RuntimeError(f"Failed to run evaluation by name: {str(e)}") from e
-
-    async def run_rag_evaluation(self, request: RAGEvaluationRequest) -> EvaluationResponse:
-        """Run a RAG evaluation with contexts asynchronously.
-
-        This method is used by the SSE server which requires async operation.
-
-        Args:
-            evaluator_id: The ID of the evaluator to use.
-            request: The RAG evaluation request parameters.
-
-        Returns:
-            EvaluationResponse: The evaluation results.
-        """
-        try:
-            logger.debug(f"Running RAG evaluation with contexts: {request.contexts}")
-            result = await self.async_client.run_evaluator(
-                evaluator_id=request.evaluator_id,
-                request=request.request,
-                response=request.response,
-                contexts=request.contexts,
-            )
-
-            return result
-        except RootSignalsAPIError as e:
-            logger.error(f"API error running RAG evaluation: {e}", exc_info=settings.debug)
-            raise RuntimeError(f"Failed to run RAG evaluation: {str(e)}") from e
-        except ResponseValidationError as e:
-            logger.error(f"Response validation error: {e}", exc_info=settings.debug)
-            if e.response_data:
-                logger.debug(f"Response data: {e.response_data}")
-            raise RuntimeError(f"Invalid RAG evaluation response: {str(e)}") from e
-        except Exception as e:
-            logger.error(f"Error running RAG evaluation: {e}", exc_info=settings.debug)
-            raise RuntimeError(f"Failed to run RAG evaluation: {str(e)}") from e
-
-    async def run_rag_evaluation_by_name(
-        self, request: RAGEvaluationByNameRequest
-    ) -> EvaluationResponse:
-        """Run a RAG evaluation with contexts using the evaluator's name instead of ID.
-
-        Args:
-            request: The RAG evaluation request parameters with evaluator name.
-
-        Returns:
-            EvaluationResponse: The evaluation results.
-        """
-        try:
-            logger.debug(f"Running RAG evaluation by name with contexts: {request.contexts}")
-            result = await self.async_client.run_evaluator_by_name(
-                evaluator_name=request.evaluator_name,
-                request=request.request,
-                response=request.response,
-                contexts=request.contexts,
-            )
-
-            return result
-        except RootSignalsAPIError as e:
-            logger.error(f"API error running RAG evaluation by name: {e}", exc_info=settings.debug)
-            raise RuntimeError(f"Failed to run RAG evaluation by name: {str(e)}") from e
-        except ResponseValidationError as e:
-            logger.error(f"Response validation error: {e}", exc_info=settings.debug)
-            if e.response_data:
-                logger.debug(f"Response data: {e.response_data}")
-            raise RuntimeError(f"Invalid RAG evaluation response: {str(e)}") from e
-        except Exception as e:
-            logger.error(f"Error running RAG evaluation by name: {e}", exc_info=settings.debug)
-            raise RuntimeError(f"Failed to run RAG evaluation by name: {str(e)}") from e

--- a/src/root_signals_mcp/evaluator.py
+++ b/src/root_signals_mcp/evaluator.py
@@ -116,6 +116,7 @@ class EvaluatorService:
                 request=request.request,
                 response=request.response,
                 contexts=request.contexts,
+                expected_output=request.expected_output,
             )
 
             return result
@@ -147,6 +148,7 @@ class EvaluatorService:
                 request=request.request,
                 response=request.response,
                 contexts=request.contexts,
+                expected_output=request.expected_output,
             )
 
             return result

--- a/src/root_signals_mcp/root_api_client.py
+++ b/src/root_signals_mcp/root_api_client.py
@@ -254,16 +254,14 @@ class RootSignalsEvaluatorRepository(RootSignalsRepositoryBase):
                     objective = evaluator_data["objective"]
                     intent = objective.get("intent")
 
-                requires_contexts = evaluator_data["requires_contexts"]
-                requires_expected_output = evaluator_data["requires_expected_output"]
+                inputs = evaluator_data["inputs"]
 
                 evaluator = EvaluatorInfo(
                     id=id_value,
                     name=name_value,
                     created_at=created_at,
                     intent=intent,
-                    requires_contexts=bool(requires_contexts),
-                    requires_expected_output=bool(requires_expected_output),
+                    inputs=inputs,
                 )
                 evaluators.append(evaluator)
             except KeyError as e:

--- a/src/root_signals_mcp/schema.py
+++ b/src/root_signals_mcp/schema.py
@@ -71,6 +71,14 @@ class BaseEvaluationRequest(BaseRootSignalsModel):
 
     request: str = Field(..., description="The user query to evaluate")
     response: str = Field(..., description="The AI assistant's response to evaluate")
+    contexts: list[str] | None = Field(
+        default=None,
+        description="List of required context strings for evaluation. Used only for evaluators that have 'contexts' defined in their inputs.",
+    )
+    expected_output: str | None = Field(
+        default=None,
+        description="The expected LLM response. Used only for evaluators that have 'expected_output' defined in their inputs.",
+    )
 
     @field_validator("request", "response")
     @classmethod
@@ -125,24 +133,6 @@ class EvaluationRequest(BaseEvaluationRequest):
     evaluator_id: str = Field(..., description="The ID of the evaluator to use")
 
 
-class RAGEvaluationRequest(EvaluationRequest):
-    """
-    Model for RAG evaluators that require contexts to be sent"""
-
-    contexts: list[str] = Field(
-        default=[], description="List of required context strings for evaluation"
-    )
-
-
-class RAGEvaluationByNameRequest(EvaluationRequestByName):
-    """
-    Model for RAG evaluators that require contexts to be sent"""
-
-    contexts: list[str] = Field(
-        default=[], description="List of required context strings for evaluation"
-    )
-
-
 class CodingPolicyAdherenceEvaluationRequest(BaseToolRequest):
     """Request model for coding policy adherence evaluation tool."""
 
@@ -172,6 +162,23 @@ class EvaluationResponse(BaseRootSignalsModel):
     cost: float | int | None = Field(None, description="Cost of the evaluation")
 
 
+class ArrayInputItem(BaseModel):
+    type: str
+
+
+class RequiredInput(BaseModel):
+    type: str
+    items: ArrayInputItem | None = None
+
+
+INPUTS_DESCRIPTION = """
+Schema defining the input parameters required for running the evaluator (run_evaluation parameters).
+If contexts are required, it means this is a RAG evaluator and you must pass contexts such as policy files, examples, etc.
+If expected_output is required, it means this is a gold standard output evaluator and you must pass the expected output.
+Request and response are required for almost all evaluators. Request is the user query and response is the model's response to evaluate.
+"""
+
+
 class EvaluatorInfo(BaseRootSignalsModel):
     """
     Model for evaluator information.
@@ -183,12 +190,18 @@ class EvaluatorInfo(BaseRootSignalsModel):
     id: str = Field(..., description="ID of the evaluator")
     created_at: str = Field(..., description="Creation timestamp of the evaluator")
     intent: str | None = Field(None, description="Intent of the evaluator")
-    requires_contexts: bool | None = Field(
-        False, description="Whether the evaluator requires context"
+    inputs: dict[str, RequiredInput] = Field(
+        ...,
+        description=INPUTS_DESCRIPTION,
     )
-    requires_expected_output: bool | None = Field(
-        False, description="Whether the evaluator requires gold standard output"
-    )
+
+    @property
+    def requires_contexts(self) -> bool:
+        return self.inputs.get("contexts") is not None
+
+    @property
+    def requires_expected_output(self) -> bool:
+        return self.inputs.get("expected_output") is not None
 
 
 class EvaluatorsListResponse(BaseRootSignalsModel):

--- a/src/root_signals_mcp/schema.py
+++ b/src/root_signals_mcp/schema.py
@@ -171,14 +171,6 @@ class RequiredInput(BaseModel):
     items: ArrayInputItem | None = None
 
 
-INPUTS_DESCRIPTION = """
-Schema defining the input parameters required for running the evaluator (run_evaluation parameters).
-If contexts are required, it means this is a RAG evaluator and you must pass contexts such as policy files, examples, etc.
-If expected_output is required, it means this is a gold standard output evaluator and you must pass the expected output.
-Request and response are required for almost all evaluators. Request is the user query and response is the model's response to evaluate.
-"""
-
-
 class EvaluatorInfo(BaseRootSignalsModel):
     """
     Model for evaluator information.
@@ -192,7 +184,7 @@ class EvaluatorInfo(BaseRootSignalsModel):
     intent: str | None = Field(None, description="Intent of the evaluator")
     inputs: dict[str, RequiredInput] = Field(
         ...,
-        description=INPUTS_DESCRIPTION,
+        description="Schema defining the input parameters required for running the evaluator (run_evaluation parameters).",
     )
 
     @property

--- a/src/root_signals_mcp/test/test_client.py
+++ b/src/root_signals_mcp/test/test_client.py
@@ -70,9 +70,7 @@ async def test_client_list_tools(compose_up_mcp_server: Any) -> None:
             "list_judges",
             "run_judge",
             "run_evaluation",
-            "run_rag_evaluation",
             "run_evaluation_by_name",
-            "run_rag_evaluation_by_name",
             "run_coding_policy_adherence",
         }
         assert expected_tools.issubset(set(tool_names)), (
@@ -218,7 +216,7 @@ async def test_client_run_evaluation_by_name(compose_up_mcp_server: Any) -> None
         evaluators = await client.list_evaluators()
 
         standard_evaluator = next(
-            (e for e in evaluators if not e.get("requires_contexts", False)), None
+            (e for e in evaluators if not e.get("inputs", {}).get("contexts")), None
         )
 
         assert standard_evaluator is not None, "No standard evaluator found"
@@ -242,7 +240,7 @@ async def test_client_run_evaluation_by_name(compose_up_mcp_server: Any) -> None
 @pytest.mark.asyncio
 async def test_client_run_rag_evaluation(compose_up_mcp_server: Any) -> None:
     """Test client run_rag_evaluation method with a real server."""
-    logger.info("Testing run_rag_evaluation")
+    logger.info("Testing run_evaluation with contexts")
     client = RootSignalsMCPClient()
 
     try:
@@ -265,7 +263,7 @@ async def test_client_run_rag_evaluation(compose_up_mcp_server: Any) -> None:
 
         logger.info(f"Using evaluator: {rag_evaluator['name']}")
 
-        result = await client.run_rag_evaluation(
+        result = await client.run_evaluation(
             evaluator_id=rag_evaluator["id"],
             request="What is the capital of France?",
             response="The capital of France is Paris, which is known as the City of Light.",
@@ -286,7 +284,7 @@ async def test_client_run_rag_evaluation(compose_up_mcp_server: Any) -> None:
 @pytest.mark.asyncio
 async def test_client_run_rag_evaluation_by_name(compose_up_mcp_server: Any) -> None:
     """Test client run_rag_evaluation_by_name method with a real server."""
-    logger.info("Testing run_rag_evaluation_by_name")
+    logger.info("Testing run_evaluation_by_name with contexts")
     client = RootSignalsMCPClient()
 
     try:

--- a/src/root_signals_mcp/test/test_evaluator.py
+++ b/src/root_signals_mcp/test/test_evaluator.py
@@ -161,6 +161,7 @@ async def test_run_evaluation_passes_correct_parameters(mock_api_client: MagicMo
         request="Test request",
         response="Test response",
         contexts=["Test context"],
+        expected_output="Test expected output",
     )
 
     result = await service.run_evaluation(request)
@@ -170,6 +171,7 @@ async def test_run_evaluation_passes_correct_parameters(mock_api_client: MagicMo
         request="Test request",
         response="Test response",
         contexts=["Test context"],
+        expected_output="Test expected output",
     )
 
     assert result.evaluator_name == "Test Evaluator"
@@ -195,6 +197,7 @@ async def test_run_evaluation_by_name_passes_correct_parameters(mock_api_client:
         request="Test request",
         response="Test response",
         contexts=["Test context"],
+        expected_output="Test expected output",
     )
 
     result = await service.run_evaluation_by_name(request)
@@ -204,6 +207,7 @@ async def test_run_evaluation_by_name_passes_correct_parameters(mock_api_client:
         request="Test request",
         response="Test response",
         contexts=["Test context"],
+        expected_output="Test expected output",
     )
 
     assert result.evaluator_name == "Test Evaluator"

--- a/src/root_signals_mcp/test/test_root_client.py
+++ b/src/root_signals_mcp/test/test_root_client.py
@@ -60,10 +60,8 @@ async def test_list_evaluators() -> None:
     assert first_evaluator.name, "Evaluator missing name"
     assert first_evaluator.created_at, "Evaluator missing created_at"
 
-    assert isinstance(first_evaluator.requires_contexts, bool), "requires_contexts is not a boolean"
-    assert isinstance(first_evaluator.requires_expected_output, bool), (
-        "requires_expected_output is not a boolean"
-    )
+    assert first_evaluator.inputs, "Evaluator missing inputs"
+    assert first_evaluator.inputs != {}, "Evaluator inputs are empty"
 
     logger.info(f"Found {len(evaluators)} evaluators")
     logger.info(f"First evaluator: {first_evaluator.name} (ID: {first_evaluator.id})")
@@ -185,7 +183,8 @@ async def test_run_evaluator_with_expected_output() -> None:
 
     evaluators = await client.list_evaluators()
     eval_with_expected = next(
-        (e for e in evaluators if e.requires_expected_output), next((e for e in evaluators), None)
+        (e for e in evaluators if e.inputs.get("expected_output") is not None),
+        next((e for e in evaluators), None),
     )
 
     if not eval_with_expected:
@@ -196,6 +195,7 @@ async def test_run_evaluator_with_expected_output() -> None:
             evaluator_id=eval_with_expected.id,
             request="What is the capital of France?",
             response="The capital of France is Paris.",
+            contexts=["Paris is the capital of France."],
             expected_output="Paris is the capital of France.",
         )
 
@@ -328,8 +328,7 @@ async def test_evaluator_missing_fields() -> None:
                     "id": "valid-id",
                     "name": "Valid Evaluator",
                     "created_at": "2023-01-01T00:00:00Z",
-                    "requires_contexts": False,
-                    "requires_expected_output": False,
+                    "inputs": {},
                 },
                 {
                     "created_at": "2023-01-01T00:00:00Z",
@@ -355,8 +354,7 @@ async def test_evaluator_missing_fields() -> None:
                     "id": "valid-id",
                     "name": "Valid Evaluator",
                     "created_at": "2023-01-01T00:00:00Z",
-                    "requires_contexts": False,
-                    "requires_expected_output": False,
+                    "inputs": {},
                 }
             ]
         }

--- a/src/root_signals_mcp/test/test_stdio_integration.py
+++ b/src/root_signals_mcp/test/test_stdio_integration.py
@@ -43,8 +43,6 @@ async def test_direct_core_list_tools() -> None:
         "list_evaluators",
         "run_evaluation",
         "run_evaluation_by_name",
-        "run_rag_evaluation",
-        "run_rag_evaluation_by_name",
         "run_coding_policy_adherence",
     }
 
@@ -128,8 +126,6 @@ async def test_stdio_client_list_tools() -> None:
                 "list_evaluators",
                 "run_evaluation",
                 "run_evaluation_by_name",
-                "run_rag_evaluation",
-                "run_rag_evaluation_by_name",
                 "run_coding_policy_adherence",
             }
 

--- a/src/root_signals_mcp/tools.py
+++ b/src/root_signals_mcp/tools.py
@@ -10,8 +10,6 @@ from root_signals_mcp.schema import (
     EvaluationRequestByName,
     ListEvaluatorsRequest,
     ListJudgesRequest,
-    RAGEvaluationByNameRequest,
-    RAGEvaluationRequest,
     RunJudgeRequest,
 )
 
@@ -31,19 +29,9 @@ def get_tools() -> list[Tool]:
             inputSchema=EvaluationRequest.model_json_schema(),
         ),
         Tool(
-            name="run_rag_evaluation",
-            description="Run a RAG evaluation with contexts using a RootSignals evaluator by ID",
-            inputSchema=RAGEvaluationRequest.model_json_schema(),
-        ),
-        Tool(
             name="run_evaluation_by_name",
             description="Run a standard evaluation using a RootSignals evaluator by name",
             inputSchema=EvaluationRequestByName.model_json_schema(),
-        ),
-        Tool(
-            name="run_rag_evaluation_by_name",
-            description="Run a RAG evaluation with contexts using a RootSignals evaluator by name",
-            inputSchema=RAGEvaluationByNameRequest.model_json_schema(),
         ),
         Tool(
             name="run_coding_policy_adherence",
@@ -79,8 +67,6 @@ def get_request_model(tool_name: str) -> type | None:
         "run_evaluation_by_name": EvaluationRequestByName,
         "run_evaluation": EvaluationRequest,
         "run_judge": RunJudgeRequest,
-        "run_rag_evaluation_by_name": RAGEvaluationByNameRequest,
-        "run_rag_evaluation": RAGEvaluationRequest,
     }
 
     return mapping.get(tool_name)


### PR DESCRIPTION
Merging the two tool calls. API calls are the same regardless of the evaluator type; only the input signatures differ.

Also:
- Also updated the EvaluatorInfo to use the new `inputs` field for determining the input signature.
- Added expected_output as a parameter for the tool call itself

Tested with cursor and pydantic-ai example and seems to work well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Evaluation methods now support passing contextual information and expected output directly, providing more flexibility for evaluators that require these inputs.

- **Refactor**
  - Unified and simplified evaluation APIs by consolidating context-based evaluation into the main evaluation methods and removing RAG-specific evaluation methods and tools.
  - Evaluator input requirements are now described using a schema-driven approach, replacing explicit boolean flags.

- **Documentation**
  - Updated documentation and usage examples to reflect the new evaluation interface and removed references to RAG evaluation.

- **Tests**
  - Updated and streamlined tests to align with the new evaluation interface and input schema, removing obsolete test cases and references to RAG-specific methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->